### PR TITLE
added storage accounts

### DIFF
--- a/resources/main.tf
+++ b/resources/main.tf
@@ -3,7 +3,7 @@
 ##################################################################################
 
 locals {
-  prefix_name = "${var.resource_naming_prefix}-${terraform.workspace}"
+  prefix_name = "${var.resources_naming_prefix}-${terraform.workspace}"
 }
 
 ##################################################################################

--- a/resources/storage-accounts.tf
+++ b/resources/storage-accounts.tf
@@ -1,0 +1,32 @@
+##################################################################################
+# Variables
+##################################################################################
+
+locals {
+  storage_account_name = "${var.resources_naming_prefix}${terraform.workspace}storageaccount"
+}
+
+##################################################################################
+# RESOURCES
+##################################################################################
+
+resource "azurerm_storage_account" "storage_acct" {
+  name                     = local.storage_account_name
+  resource_group_name      = azurerm_resource_group.rg_integration_resources.name
+  location                 = azurerm_resource_group.rg_integration_resources.location
+  account_tier             = "Standard"
+  account_replication_type = "RAGRS"
+  allow_blob_public_access = false
+}
+
+resource "azurerm_storage_container" "example" {
+  name                  = "mycontainer"
+  storage_account_name  = azurerm_storage_account.storage_acct.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_share" "example" {
+  name                 = "sharename"
+  storage_account_name = azurerm_storage_account.storage_acct.name
+  quota                = 5120
+}

--- a/resources/terraform.tfvars
+++ b/resources/terraform.tfvars
@@ -1,4 +1,4 @@
-resource_naming_prefix = "dc"
+resources_naming_prefix = "dc"
 resource_location = "eastus"
 arm_environment = "public"
 integration_acct_sku = "Free"

--- a/resources/variables.tf
+++ b/resources/variables.tf
@@ -1,7 +1,7 @@
 ##################################################################################
 # VARIABLES
 ##################################################################################
-variable "resource_naming_prefix" {
+variable "resources_naming_prefix" {
   type    = string
   default = "dc"
 }


### PR DESCRIPTION
added terraform scripts to create storage accounts.  Had an issue with the v2.19 of the Terraform Azure provider when using it with US Government cloud.  The allow_blob_public_access flag has not been implemented in storage accounts in US Government, but is there in Public clouds.  Therefore, cannot upgrade to newest version when using US government cloud.